### PR TITLE
Small update on examples by adding missing object references

### DIFF
--- a/workshop/style-parser/convert.md
+++ b/workshop/style-parser/convert.md
@@ -62,7 +62,7 @@ olParser.readStyle(olStyle)
     })
     .then((sld) => {
         // Run your actions with the converted style here
-        console.log(sld);
+        console.log(sld.output);
     });
 ```
 

--- a/workshop/style-parser/parse-ol.md
+++ b/workshop/style-parser/parse-ol.md
@@ -51,7 +51,7 @@ This can now be parsed via `readStyle` and `writeStyle`
 olParser.readStyle(olStyle)
     .then((geostylerStyle) => {
         // Run your actions with the read style here, e.g.
-        console.log(geostylerStyle);
+        console.log(geostylerStyle.output);
     });
 
 olParser.writeStyle(geostylerStyle)

--- a/workshop/style-parser/parse-sld.md
+++ b/workshop/style-parser/parse-sld.md
@@ -34,7 +34,7 @@ a SLD string as argument and returns a [Promise](https://developer.mozilla.org/e
 sldParser.readStyle(sld)
     .then((geostylerStyle) => {
         // Run your actions with the parsed style here, e.g.
-        console.log(geostylerStyle);
+        console.log(geostylerStyle.output);
     });
 ```
 
@@ -45,7 +45,7 @@ a GeoStyler style object as argument and returns a Promise with the matching SLD
 sldParser.writeStyle(geostylerStyle)
     .then((sld) => {
         // Run your actions with the written style here, e.g.
-        console.log(sld);
+        console.log(sld.output);
     });
 ```
 


### PR DESCRIPTION
added missing object reference to console.log()'s on examples in: 
- convert.md 
- parse-ol.md 
- parse sld.md